### PR TITLE
fix: Updated research blog url contained in the CV

### DIFF
--- a/sections/research.tex
+++ b/sections/research.tex
@@ -39,7 +39,7 @@
   \myItemListEnd
 
   \mySubHeadingLess
-  {\href{https://spencer.imbleau.com/blog}{\myuline{My Research Blog}}}
+  {\href{https://simbleau.github.io/}{\myuline{My Research Blog}}}
   {Dec 2021 -- Present}
   \myItemListStart
     \myItem{An open source initiative to provide free and insightful information}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Updates the research blog URL to the new website

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The previous URL was sending people to a 404 Not Found Page because the research blog was transferred to a new website.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

### The effect of clicking on the "My Research Blog" link. ( I have dark reader )

Before: 
![image](https://github.com/simbleau/resume/assets/103440971/6c3c6eaf-9584-4064-b1dd-c1c2036b93f2)


After: 
![image](https://github.com/simbleau/resume/assets/103440971/a5c384cd-9cfd-4a46-b435-5953dfab7151)


